### PR TITLE
Post deploy fixes

### DIFF
--- a/libs/nx-terraform/README.md
+++ b/libs/nx-terraform/README.md
@@ -41,7 +41,7 @@ This plugin has 2 levels of generators, the first level operates at the reposito
 
 ### Init
 
-Ensure you have run `pnpm exec nx g @arkahna/nx-terraform:tf-init` to setup the repo
+Ensure you have run `pnpm exec nx g @arkahna/nx-terraform:init` to setup the repo
 
 The plugin supports both terraform cloud and azure storage.
 

--- a/libs/nx-terraform/src/common/read-repo-settings.ts
+++ b/libs/nx-terraform/src/common/read-repo-settings.ts
@@ -18,12 +18,12 @@ export function readRepoSettings() {
 
     if (!azureResourcePrefix) {
         throw new Error(
-            'azureResourcePrefix is not defined in root package.json, run pnpm nx g @arkahna/nx-terraform:tf-init'
+            'azureResourcePrefix is not defined in root package.json, run pnpm nx g @arkahna/nx-terraform:init'
         )
     }
     if (!['terraform-cloud', 'azure-storage'].includes(terraformStateType)) {
         throw new Error(
-            'terraformStateType is not defined in root package.json or is not one of terraform-cloud, azure-storage, run pnpm nx g @arkahna/nx-terraform:tf-init'
+            'terraformStateType is not defined in root package.json or is not one of terraform-cloud, azure-storage, run pnpm nx g @arkahna/nx-terraform:init'
         )
     }
 

--- a/libs/nx-terraform/src/generators/add-project-environment/state-type/azure-storage/terragrunt.hcl
+++ b/libs/nx-terraform/src/generators/add-project-environment/state-type/azure-storage/terragrunt.hcl
@@ -13,7 +13,6 @@ remote_state {
     storage_account_name = "<%= storageAccountName %>"
     container_name       = "<%= containerName %>"
     key                  = "<%= storageKey %>"
-    use_azuread_auth     = true
     use_oidc             = true
   }
 }

--- a/libs/nx-terraform/src/generators/init/schema.json
+++ b/libs/nx-terraform/src/generators/init/schema.json
@@ -51,5 +51,5 @@
             "description": "Cost centre of the Azure resources this repository deploys"
         }
     },
-    "required": []
+    "required": ["azureWorkloadCode","azureResourcePrefix"]
 }


### PR DESCRIPTION
Found 3 small issues upon using this package:

- Requirements in nx-terraform:init not specified, leading to failed deployments.
- Error messages lead to incorrect command.
- Main.tf generated on terragrunt run is using an unsupported argument (use_azuread_auth).
  - This variable is for use within the Backend block, not the Provider block
