### PR TITLE
Fixed Retrieving Environments Directory

### DIFF
--- a/.changeset/funny-trainers-stare.md
+++ b/.changeset/funny-trainers-stare.md
@@ -1,0 +1,5 @@
+---
+'@arkahna/nx-terraform': patch
+---
+
+Fix issue where nx is unable to find environments directory configured in nx.json

--- a/libs/nx-terraform/src/generators/create-azure-environment/getEnvironmentsDir.ts
+++ b/libs/nx-terraform/src/generators/create-azure-environment/getEnvironmentsDir.ts
@@ -4,7 +4,7 @@ export function getEnvironmentsDir(projectName: string | undefined) {
     const nxJson = readNxJson()
     const environmentsDir =
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (nxJson as any)?.nxTerraformLayout?.environmentsDirectory || 'docs/environments'
+        (nxJson as any)?.nxTerraformLayout?.environmentsDir || 'docs/environments'
 
     if (projectName) {
         return environmentsDir.replace('{project}', projectName)


### PR DESCRIPTION
Fixed getEnvironmentsDir function to look for `environmentsDir` property to match existing documentation in readme and other properties supplied (e.g. modulesDir, appsDir), which was always causing project-specific environments to default to `docs/environments`